### PR TITLE
AFKR-2: Added global property configurations for CloseStaleVisitsTask

### DIFF
--- a/configuration/globalproperties/scheduler_gp.xml
+++ b/configuration/globalproperties/scheduler_gp.xml
@@ -1,0 +1,12 @@
+<config>
+  <globalProperties>
+    <globalProperty>
+      <property>emrapi.visitExpireHours</property>
+      <value>0</value>
+    </globalProperty>
+    <globalProperty>
+      <property>visits.autoCloseVisitType</property>
+      <value>Ambulatoire</value>
+    </globalProperty>
+  </globalProperties>
+</config>


### PR DESCRIPTION
There are two global properties we want to configure for easyDoc system:

1. **emrapi.visitExpireHours**: We set this to zero as we want the scheduled task to close visits regardless of when they were created. Meaning if we configure the scheduled task to run every 24 hours, starting from midnight, a visit created at 5 pm on that same day for example (...on that same day) will be close too.

2. **visits.autoCloseVisitType**: We set this to '**Ambulatoire**'. This means the scheduler will only handle visit of "**Ambulatoire**" visit type.